### PR TITLE
Preliminary Apple Music support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ Global commands (no rooms required):
 * Presets: "Alexa, tell Sonos to play Rock"
 * Pause all: "Alexa, tell Sonos to pause all"
 * Resume all: "Alexa, tell Sonos to resume all"
+* Apple Music: "Alexa, tell Sonos to play SONGNAME by ARTISTNAME from Apple Music"
 
 Room-specific commands, where "ROOM" could be any of your Sonos room names (eg Kitchen, Master Bedroom, and so on):
 
 * Playlists: "Alexa, tell Sonos to start playlist MY PLAYLIST in the ROOM"
 * Favorites: "Alexa, tell Sonos to play favorite MY FAVORITE in the ROOM"
+* Apple Music: "Alexa, tell Sonos to play SONGNAME by ARTISTNAME in the ROOM from Apple Music"
 * Next: "Alexa, tell Sonos go to the next track in the ROOM"
 * Previous: "Alexa, tell Sonos to go back in the ROOM"
 * What's playing: "Alexa, ask Sonos what's playing in the ROOM"

--- a/echo/intents.json
+++ b/echo/intents.json
@@ -9,7 +9,43 @@
             }
         ]
     },
- 
+      
+    {
+        "intent": "AppleMusicIntent",
+        "slots": [
+            {
+                "name": "SongName",
+                "type": "AMAZON.LITERAL"
+            },
+            {
+                "name": "ArtistName",
+                "type": "AMAZON.LITERAL"
+            },
+            {
+                "name": "Room",
+                "type": "ROOMS"
+            }
+        ]
+    },
+
+    {
+        "intent": "AppleMusicAlbumIntent",
+        "slots": [
+            {
+                "name": "AlbumName",
+                "type": "AMAZON.LITERAL"
+            },
+            {
+                "name": "ArtistName",
+                "type": "AMAZON.LITERAL"
+            },
+            {
+                "name": "Room",
+                "type": "ROOMS"
+            }
+        ]
+    },
+
     {
       "intent": "PlaylistIntent",
       "slots": [
@@ -204,4 +240,3 @@
     }
   ]
 }
-

--- a/echo/utterances.txt
+++ b/echo/utterances.txt
@@ -1,5 +1,53 @@
 PlayIntent play {Preset}
 
+AppleMusicIntent play {crash|SongName} in {Room} from apple music
+AppleMusicIntent play {Ho Hey|SongName} in {Room} from apple music
+AppleMusicIntent play {beast of burden|SongName} in {Room} from apple music
+AppleMusicIntent play {I knew you were trouble|SongName} in the {Room} from apple music
+AppleMusicIntent play {Sgt. Peppers lonley heart club band|SongName} in the {Room} from apple music
+AppleMusicIntent play {Macarena|SongName} in the {Room} from apple music
+AppleMusicIntent play {my heart will go on|SongName} in the {Room} from apple music
+AppleMusicIntent play {every breathe you take|SongName} in the {Room} from apple music
+
+AppleMusicIntent play {crash|SongName} from apple music
+AppleMusicIntent play {Ho Hey|SongName} from apple music
+AppleMusicIntent play {beast of burden|SongName} from apple music
+AppleMusicIntent play {I knew you were trouble|SongName} from apple music
+AppleMusicIntent play {Sgt. Peppers lonley heart club band|SongName} from apple music
+AppleMusicIntent play {Macarena|SongName} from apple music
+AppleMusicIntent play {my heart will go on|SongName} from apple music
+AppleMusicIntent play {every breathe you take|SongName} from apple music
+
+AppleMusicIntent play {crash|SongName} by {Dave Matthews Band|ArtistName} in {Room} from apple music
+AppleMusicIntent play {Ho Hey|SongName} by {The Lumineers|ArtistName} in {Room} from apple music
+AppleMusicIntent play {beat of our noisy hearts|SongName} by {Matt Nathanson|ArtistName} in {Room} from apple music
+AppleMusicIntent play {trouble|SongName} by {Taylor Swift|ArtistName} in {Room} from apple music
+AppleMusicIntent play {sixty four|SongName} by {the beatles|ArtistName} in the {Room} from apple music
+AppleMusicIntent play {beast of burden|SongName} by {the rolling stones|ArtistName} in the {Room} from apple music
+AppleMusicIntent play {the twist|SongName} by {chubby checker|ArtistName} in the {Room} from apple music
+
+AppleMusicIntent play {crash|SongName} by {Dave Matthews Band|ArtistName} from apple music
+AppleMusicIntent play {Ho Hey|SongName} by {The Lumineers|ArtistName} from apple music
+AppleMusicIntent play {beat of our noisy hearts|SongName} by {Matt Nathanson|ArtistName} from apple music
+AppleMusicIntent play {trouble|SongName} by {Taylor Swift|ArtistName} from apple music
+AppleMusicIntent play {sixty four|SongName} by {the beatles|ArtistName} from apple music
+AppleMusicIntent play {beast of burden|SongName} by {the rolling stones|ArtistName} from apple music
+AppleMusicIntent play {the twist|SongName} by {chubby checker|ArtistName} from apple music
+
+AppleMusicAlbumIntent play album {crash|AlbumName} by {Dave Matthews Band|ArtistName} in {Room} from apple music
+AppleMusicAlbumIntent play album {Sublime|AlbumName} by {Sublime|ArtistName} in {Room} from apple music
+AppleMusicAlbumIntent play album {Modern Love|AlbumName} by {Matt Nathanson|ArtistName} in {Room} from apple music
+AppleMusicAlbumIntent play album {Red|AlbumName} by {Taylor Swift|ArtistName} in the {Room} from apple music
+AppleMusicAlbumIntent play album {Sgt. Peppers lonley heart club band|AlbumName} by {the beatles|ArtistName} in the {Room} from apple music
+AppleMusicAlbumIntent play album {Exile on main street|AlbumName} by {the rolling stones|ArtistName} in the {Room} from apple music
+
+AppleMusicAlbumIntent play album {crash|AlbumName} by {Dave Matthews Band|ArtistName} from apple music
+AppleMusicAlbumIntent play album {Sublime|AlbumName} by {Sublime|ArtistName} from apple music
+AppleMusicAlbumIntent play album {Modern Love|AlbumName} by {Matt Nathanson|ArtistName} from apple music
+AppleMusicAlbumIntent play album {Red|AlbumName} by {Taylor Swift|ArtistName} from apple music
+AppleMusicAlbumIntent play album {Sgt. Peppers lonley heart club band|AlbumName} by {the beatles|ArtistName} from apple music
+AppleMusicAlbumIntent play album {Exile on main street|AlbumName} by {the rolling stones|ArtistName} from apple music
+
 PlaylistIntent playlist {Preset} in {Room}
 PlaylistIntent playlist {Preset} in the {Room}
 PlaylistIntent play playlist {Preset} in {Room}


### PR DESCRIPTION
This uses the additions in jishi/node-sonos-http-api#180 to add support for Apple Music. It uses an [AMAZON.LITERAL](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/alexa-skills-kit-interaction-model-reference#LITERAL%20Slot%20Type%20Reference) Slot Type and the [iTunes Search API](https://affiliate.itunes.apple.com/resources/documentation/itunes-store-web-service-search-api/) to find songs and albums. Then it queues them up and plays them.

Right now, it requires the user to finish the request with "from Apple Music". My feeling is that this might be a bit cumbersome for someone (like me!) who only really uses one music service, so perhaps we could figure out a way to make to more easily configurable (maybe a preset that specifies the default music service and a generic intent for playing songs and albums?).

(Sorry for all of the non-functional whitespace diffs, my vim linter removes trailing whitespace automatically, so it's a bit hard for me to avoid.)