### PR TITLE
Add JoinGroup and IsolateGroup intents

### DIFF
--- a/echo/intents.json
+++ b/echo/intents.json
@@ -201,7 +201,32 @@
             "type": "ROOMS"
         }
       ]
+    },
+    
+    {
+      "intent": "JoinGroupIntent",
+      "slots": [
+        {
+          "name": "JoiningRoom",
+          "type": "ROOMS"
+        },
+        {
+          "name": "PlayingRoom",
+          "type": "ROOMS"
+        }
+      ]
+    },
+    
+    {
+      "intent" : "UngroupIntent",
+      "slots" : [
+        {
+          "name" : "Room",
+          "type" : "ROOMS"
+        }
+      ]
     }
+    
   ]
 }
 

--- a/echo/utterances.txt
+++ b/echo/utterances.txt
@@ -183,3 +183,14 @@ CrossfadeIntent turn crossfade {Toggle} in {Room}
 CrossfadeIntent turn crossfade {Toggle} in the {Room}
 CrossfadeIntent crossfade {Toggle} in {Room}
 CrossfadeIntent crossfade {Toggle} in the {Room}
+
+JoinGroupIntent join {JoiningRoom} to {PlayingRoom}
+JoinGroupIntent join the {JoiningRoom} to {PlayingRoom}
+JoinGroupIntent join {JoiningRoom} to the {PlayingRoom}
+JoinGroupIntent join the {JoiningRoom} to the {PlayingRoom}
+
+UngroupIntent ungroup {Room}
+UngroupIntent ungroup the {Room}
+UngroupIntent isolate {Room}
+UngroupIntent isolate the {Room}
+

--- a/lambda/src/index.js
+++ b/lambda/src/index.js
@@ -155,6 +155,23 @@ EchoSonos.prototype.intentHandlers = {
         console.log("CrossfadeIntent received");
         toggleHandler(intent.slots.Room.value, intent.slots.Toggle.value, "crossfade", response);
     },
+    
+    UngroupIntent: function (intent, session, response) {
+        console.log("UngroupIntent received");
+        options.path = '/' + encodeURIComponent(intent.slots.Room.value) + '/isolate';
+        httpreq(options, function(error) {
+            genericResponse(error, response);
+        });
+    },
+   
+    JoinGroupIntent: function (intent, session, response) {
+        console.log("JoinGroupIntent received");
+        options.path = '/' + encodeURIComponent(intent.slots.JoiningRoom.value) + '/join/' 
+                + encodeURIComponent(intent.slots.PlayingRoom.value);
+        httpreq(options, function(error) {
+            genericResponse(error, response);
+        });
+    }
 }
 
 /** Handles playlists and favorites */


### PR DESCRIPTION
My attempt to resolve #16.  The node-sonos-http-api has a few different API calls related to grouping, but I just focused on two use cases that make sense to me.

* Add JoiningRoom to PlayingRoom will result in JoiningRoom playing whatever PlayingRoom had.
* Isolate/Ungroup Room will remove Room from whatever group it was previously a member of.