### PR TITLE
Use Amazon's newer built-in music slots for accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,9 @@ Global commands (no rooms required):
 Room-specific commands, where "ROOM" could be any of your sonos room names (eg Kitchen, Master Bedroom, and so on):
 
 * Play songs from an artist: "Alexa, ask sonos to play ARTIST NAME in the ROOM"
-* Play a song: "Alexa, ask sonos to play SONG NAME in the ROOM"
-* Play a specific artist's song: "Alexa, ask sonos to play ARTIST NAME SONG NAME in the ROOM"
+* Play songs from an album: "Alexa, ask sonos to play album ALBUM NAME in the ROOM"
+* Play a song: "Alexa, ask sonos to play the song SONG NAME in the ROOM"
 * Play "radio" songs like this artist: "Alexa, ask sonos to play ARTIST NAME radio in the ROOM"
-* Play "radio" songs like this track: Alexa, ask sonos to play SONG NAME radio in the ROOM"
-* Play "radio" songs like this track from a specific artist: "Alexa, ask sonos to play ARTIST NAME SONG NAME radio in the ROOM"
 * Play more "radio" songs like this song: "Alexa, play more songs by this artist in the ROOM"
 * Play more "radio" songs like this track: "Alexa, play more songs like this in the ROOM"
 * SiriusXM: "Alexa, play SiriusXM channel CHANNEL in the ROOM"

--- a/echo/intents.json
+++ b/echo/intents.json
@@ -1,73 +1,59 @@
 {
     "intents": [
-    
-    {
-      "intent": "MusicIntent",
-      "slots": [
-        {
-            "name": "Name",
-            "type": "NAMES"
-        },
-        {
-            "name": "Room",
-            "type": "ROOMS"
-        }   
-      ]
-    },
-    
+
     {
       "intent": "AlbumIntent",
       "slots": [
         {
-            "name": "Name",
-            "type": "NAMES"
+            "name": "AlbumName",
+            "type": "AMAZON.MusicAlbum"
         },
         {
             "name": "Room",
             "type": "ROOMS"
-        }   
+        }
       ]
     },
-      
-    {
-      "intent": "ArtistIntent",
-      "slots": [
-        {
-            "name": "Name",
-            "type": "NAMES"
-        },
-        {
-            "name": "Room",
-            "type": "ROOMS"
-        }   
-      ]
-    },
-      
+
     {
       "intent": "TrackIntent",
       "slots": [
         {
-            "name": "Name",
-            "type": "NAMES"
+            "name": "TrackName",
+            "type": "AMAZON.MusicRecording"
         },
         {
             "name": "Room",
             "type": "ROOMS"
-        }   
+        }
       ]
     },
-      
+
+    {
+      "intent": "ArtistIntent",
+      "slots": [
+        {
+            "name": "ArtistName",
+            "type": "AMAZON.MusicGroup"
+        },
+        {
+            "name": "Room",
+            "type": "ROOMS"
+        }
+      ]
+    },
+
     {
       "intent": "MusicRadioIntent",
       "slots": [
         {
-            "name": "Name",
-            "type": "NAMES"
+            "name": "ArtistName",
+            "type": "AMAZON.MusicGroup"
         },
         {
             "name": "Room",
             "type": "ROOMS"
-        }   
+        }
       ]
     },
 

--- a/echo/utterances.txt
+++ b/echo/utterances.txt
@@ -18,30 +18,33 @@ PlayMoreLikeTrackIntent play more songs like this
 PlayMoreLikeTrackIntent play more tracks like this
 PlayMoreLikeTrackIntent play more music like this
 
-MusicIntent play {Name} in the {Room}
-MusicIntent play {Name} in {Room}
+AlbumIntent play album {AlbumName} in the {Room}
+AlbumIntent play album {AlbumName} in {Room}
 
-MusicIntent play {Name}
+AlbumIntent play album {AlbumName}
 
-AlbumIntent play album {Name} in the {Room}
-AlbumIntent play album {Name} in {Room}
+ArtistIntent play artist {ArtistName} in the {Room}
+ArtistIntent play artist {ArtistName} in {Room}
 
-AlbumIntent play album {Name}
+ArtistIntent play artist {ArtistName}
 
-ArtistIntent play artist {Name} in the {Room}
-ArtistIntent play artist {Name} in {Room}
+ArtistIntent play {ArtistName} in the {Room}
+ArtistIntent play {ArtistName} in {Room}
 
-ArtistIntent play artist {Name}
+ArtistIntent play {ArtistName}
 
-TrackIntent play track {Name} in the {Room}
-TrackIntent play track {Name} in {Room}
+TrackIntent play track {TrackName} in the {Room}
+TrackIntent play track {TrackName} in {Room}
 
-TrackIntent play track {Name}
+TrackIntent play the song {TrackName} in {Room}
+TrackIntent play the song {TrackName} in the {Room}
 
-MusicRadioIntent play {Name} radio in the {Room}
-MusicRadioIntent play {Name} radio in {Room}
+TrackIntent play track {TrackName}
 
-MusicRadioIntent play {Name} radio
+MusicRadioIntent play {ArtistName} radio in the {Room}
+MusicRadioIntent play {ArtistName} radio in {Room}
+
+MusicRadioIntent play {ArtistName} radio
 
 PlayPresetIntent play preset {Preset}
 

--- a/lambda/src/index.js
+++ b/lambda/src/index.js
@@ -34,36 +34,29 @@ EchoSonos.prototype.intentHandlers = {
     AlbumIntent: function (intent, session, response) {
         console.log("AlbumIntent received");
         loadCurrentRoomAndService('DefaultEcho', intent.slots.Room.value, function(room, service) {
-        	musicHandler(room, service, '/album/', intent.slots.Name.value, response);
-        });  
+	       musicHandler(room, service, '/album/', intent.slots.AlbumName.value, response);
+        });
     },
 
     ArtistIntent: function (intent, session, response) {
         console.log("MusicIntent received for room " + intent.slots.Room.value);
         loadCurrentRoomAndService('DefaultEcho', intent.slots.Room.value, function(room, service) {
-	        musicHandler(room, service, '/song/', 'artist:' + intent.slots.Name.value, response);
-        });  
+	        musicHandler(room, service, '/song/', 'artist:' + intent.slots.ArtistName.value, response);
+        });
     },
 
     TrackIntent: function (intent, session, response) {
         console.log("MusicIntent received for room " + intent.slots.Room.value);
         loadCurrentRoomAndService('DefaultEcho', intent.slots.Room.value, function(room, service) {
-	        musicHandler(room, service, '/song/', 'track:' + intent.slots.Name.value, response);
-        });  
-    },
-
-    MusicIntent: function (intent, session, response) {
-        console.log("MusicIntent received for room " + intent.slots.Room.value);
-        loadCurrentRoomAndService('DefaultEcho', intent.slots.Room.value, function(room, service) {
-	        musicHandler(room, service, '/song/', intent.slots.Name.value, response);
-        });  
+	        musicHandler(room, service, '/song/', 'track:' + intent.slots.TrackName.value, response);
+        });
     },
 
     MusicRadioIntent: function (intent, session, response) {
         console.log("MusicRadioIntent received");
         loadCurrentRoomAndService('DefaultEcho', intent.slots.Room.value, function(room, service) {
-	        musicHandler(room, service, '/station/', intent.slots.Name.value, response);
-        });  
+	        musicHandler(room, service, '/station/', intent.slots.ArtistName.value, response);
+        });
     },
 
     PlayMoreByArtistIntent: function (intent, session, response) {


### PR DESCRIPTION
A few months ago, Amazon extended their default built-in intents with some new music-related ones:

https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/built-in-intent-ref/slot-type-reference#musicgroup

This pull request changes the intents, utterances, and lambda functions to use these instead. The accuracy in my experience with these slot types is much better.

Note that this also changes the behavior of the basic "play X" or "play X in the room" to assume it's an artist. Open to feedback on whether we want to do something different here, but given how it's easy to specify that you meant track/artist instead, and we'll get better accuracy by letting Amazon know what we're looking for, I think being more explicit is better.