### PR TITLE
Add async as dependency

### DIFF
--- a/echo-sqs-proxy/package.json
+++ b/echo-sqs-proxy/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/jplourde5/node-sonos-http-api.git"
   },
   "dependencies": {
+    "async": "^2.4.1",
     "aws-sdk": "^2.4.13",
     "request": "~2.74.0",
     "sqs-consumer": "^3.2.0"


### PR DESCRIPTION
My echo-sqs-proxy was erroring out without async, so I added async as a dependency (compatible with 2.4.1, the latest version) to package.json just to make sure it comes in with the npm install.