### PR TITLE
Allow setting env variables to logical false via lambda console

### DIFF
--- a/lambda/src/options.example.js
+++ b/lambda/src/options.example.js
@@ -32,11 +32,19 @@ var options = {
 
 module.exports = options;
 
+
 function getDefault(key, defaultVal) {
   if (typeof(process.env[key]) == 'undefined') { 
     return defaultVal;
   }
   else {
+    // special case true and false because they need to be set to logical values, not strings
+    if (process.env[key] == 'false') {
+      return false
+    }
+    if (process.env[key] == 'true') {
+      return true
+    }
     return process.env[key];
   }
 }


### PR DESCRIPTION
Users could not set any environment variable to false via the lambda console.

The issue is that the code was setting the environment variable to
string value "true" and string value "false" which are both truthy.

only users trying to use node-sonos via http noticed this bug because
there are only two boolean env vars: one is useSQS and if you are ok
with true for this, you don't care what the value of useHttps is.